### PR TITLE
Resolves issue #209

### DIFF
--- a/src/petl/test/transform/test_reshape.py
+++ b/src/petl/test/transform/test_reshape.py
@@ -63,6 +63,29 @@ def test_melt_empty():
     actual = melt(table, key='foo')
     ieq(expect, actual)
 
+def test_melt_nokey():
+
+    table = (('id', 'gender', 'age'),
+             (1, 'F', 12),
+             (2, 'M', 17),
+             (3, 'M', 16))
+
+    expectation = (('id', 'variable', 'value'),
+                   (1, 'gender', 'F'),
+                   (1, 'age', 12),
+                   (2, 'gender', 'M'),
+                   (2, 'age', 17),
+                   (3, 'gender', 'M'),
+                   (3, 'age', 16))
+
+    # key argument not specified
+    result = melt(table, variables=['gender', 'age'])
+    ieq(expectation, result)
+
+    # key argument not specified
+    result = melt(table, variables=['gender', 'age'], variablefield='variable', valuefield='value')
+    ieq(expectation, result)
+
 def test_melt_non_string_key():
 
     table = ((0.0, 'gender', 'age'),
@@ -83,6 +106,11 @@ def test_melt_non_string_key():
 
     result = melt(table, key=0.0, variablefield='variable', valuefield='value')
     ieq(expectation, result)
+
+    # check if key not specified
+    result = melt(table, variables=['gender', 'age'], variablefield='variable', valuefield='value')
+    ieq(expectation, result)
+
 
 def test_recast_1():
 

--- a/src/petl/test/transform/test_reshape.py
+++ b/src/petl/test/transform/test_reshape.py
@@ -63,6 +63,26 @@ def test_melt_empty():
     actual = melt(table, key='foo')
     ieq(expect, actual)
 
+def test_melt_non_string_key():
+
+    table = ((0.0, 'gender', 'age'),
+             (1, 'F', 12),
+             (2, 'M', 17),
+             (3, 'M', 16))
+
+    expectation = ((0.0, 'variable', 'value'),
+                   (1, 'gender', 'F'),
+                   (1, 'age', 12),
+                   (2, 'gender', 'M'),
+                   (2, 'age', 17),
+                   (3, 'gender', 'M'),
+                   (3, 'age', 16))
+
+    result = melt(table, key=0.0)
+    ieq(expectation, result)
+
+    result = melt(table, key=0.0, variablefield='variable', valuefield='value')
+    ieq(expectation, result)
 
 def test_recast_1():
 

--- a/src/petl/transform/reshape.py
+++ b/src/petl/transform/reshape.py
@@ -117,8 +117,16 @@ def itermelt(source, key, variables, variablefield, valuefield):
 
     # normalise some stuff
     flds = it.next()
+
+    # key needs to be iterable, but strings are iterable - normalise to tuple
     if isinstance(key, basestring):
-        key = (key,) # normalise to a tuple
+        key = (key,)    # normalise to a tuple if a basestring
+    # key is another type - see if it can iterate, otherwise normalise to tuple
+    else:
+        try:
+            iter(key)   # check if the key is already iterable
+        except:
+            key = (key,)    # normalise to a tuple if not iterable
     if isinstance(variables, basestring):
         # shouldn't expect this, but ... ?
         variables = (variables,) # normalise to a tuple

--- a/src/petl/transform/reshape.py
+++ b/src/petl/transform/reshape.py
@@ -118,21 +118,24 @@ def itermelt(source, key, variables, variablefield, valuefield):
     # normalise some stuff
     flds = it.next()
 
-    # key needs to be iterable, but strings are iterable - normalise to tuple
+    # ensure key is iterable object
     if isinstance(key, basestring):
         key = (key,)    # normalise to a tuple if a basestring
-    # key is another type - see if it can iterate, otherwise normalise to tuple
+    # check if key is not specified
+    elif key is None:
+        # assume key is fields not in variables
+        key = [f for f in flds if f not in variables]
+    # key needs to be iterable, but strings are iterable - normalise to tuple
     else:
         try:
             iter(key)   # check if the key is already iterable
-        except:
+        except TypeError:
+            # Non-iterable object
             key = (key,)    # normalise to a tuple if not iterable
+
     if isinstance(variables, basestring):
         # shouldn't expect this, but ... ?
         variables = (variables,) # normalise to a tuple
-    if not key:
-        # assume key is fields not in variables
-        key = [f for f in flds if f not in variables]
     if not variables:
         # assume variables are fields not in key
         variables = [f for f in flds if f not in key]


### PR DESCRIPTION
Resolves issue #209 (https://github.com/alimanfoo/petl/issues/209): melt() chokes on non-string key arg

petl.transform.reshape.itermelt() only requires that key is iterable

Existing code accepted key as either a basestring or as an iterable object.  ints, floats, etc. failed these cases, and resulted in non-iterable keys

unittest added: petl.test.transform.text_reshape.test_melt_non_string_key()