### PR TITLE
Catches ValueError thrown when sys.stdin is a pseudofile

### DIFF
--- a/petl/io/sources.py
+++ b/petl/io/sources.py
@@ -132,7 +132,7 @@ def _get_stdin_binary():
     try:
         fd = sys.stdin.fileno()
         return os.fdopen(fd, 'rb', 0)
-    except (AttributeError, OSError):
+    except (AttributeError, OSError, ValueError):
         pass
     try:
         return sys.__stdin__.buffer


### PR DESCRIPTION
When using py.test it redirect stdin/stdout in pseudofiles by
default. Pseudofiles do not provide a fileno() method and as such
raise a `ValueError` as soon as `petl.io.sources` is imported (as shown
below).

```
tests/transform/test_transforms.py:1: in <module>
    import petl
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/petl/__init__.py:9: in <module>
    from petl import util
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/petl/util/__init__.py:13: in <module>
    from petl.util.vis import look, lookall, lookstr, lookallstr, see
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/petl/util/vis.py:12: in <module>
    from petl.io.sources import MemorySource
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/petl/io/__init__.py:3: in <module>
    from petl.io.sources import FileSource, GzipSource, BZ2Source, ZipSource, \
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/petl/io/sources.py:150: in <module>
    stdin_binary = _get_stdin_binary()
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/petl/io/sources.py:133: in _get_stdin_binary
    fd = sys.stdin.fileno()
../../.virtualenvs/ernie/local/lib/python2.7/site-packages/_pytest/capture.py:441: in fileno
    raise ValueError("redirected Stdin is pseudofile, has no fileno()")
E   ValueError: redirected Stdin is pseudofile, has no fileno()
```

Simply adding `ValueError` to the tuple of caught exceptions resolves the issues.