### PR TITLE
Use lxml if available to enable parent traversal in xml source

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -11,3 +11,4 @@ numexpr
 tables
 intervaltree
 whoosh
+lxml

--- a/petl/io/xml.py
+++ b/petl/io/xml.py
@@ -3,7 +3,15 @@ from __future__ import absolute_import, print_function, division
 
 
 # standard library dependencies
-from xml.etree import ElementTree
+try:
+  from lxml import etree
+except ImportError:
+    try:
+    # normal ElementTree install
+        import xml.etree.ElementTree as etree
+    except ImportError:
+        print("Failed to import ElementTree from any known place")
+
 from operator import attrgetter
 import itertools
 from petl.compat import string_types, text_type
@@ -158,7 +166,7 @@ class XmlView(Table):
 
         with self.source.open('rb') as xmlf:
 
-            tree = ElementTree.parse(xmlf)
+            tree = etree.parse(xmlf)
             if not hasattr(tree, 'iterfind'):
                 # Python 2.6 compatibility
                 tree.iterfind = tree.findall


### PR DESCRIPTION
I found that the ElementTree library built in to Python did not allow for true XPath support (which meant that I was not able to traverse up from a child row selector to find information about a parent while building a table). This patch allows the optional dependency [lxml](http://lxml.de/) which fully supports XPath (and is a drop-in replacement in most cases for ElementTree, adhering to the API pretty strictly).