### PR TITLE
Petl.tocsv() expots 'None' string instead of no value

### DIFF
--- a/petl/io/csv_py2.py
+++ b/petl/io/csv_py2.py
@@ -164,7 +164,7 @@ class UnicodeWriter:
         self.encoder = codec.incrementalencoder(errors)
 
     def writerow(self, row):
-        self.writer.writerow([unicode(s).encode('utf-8') for s in row])
+        self.writer.writerow([unicode(s).encode('utf-8') if not s==None else None for s in row])
         # Fetch UTF-8 output from the queue ...
         data = self.queue.getvalue()
         data = data.decode('utf-8')

--- a/petl/test/io/test_csv_unicode.py
+++ b/petl/test/io/test_csv_unicode.py
@@ -126,3 +126,26 @@ def test_appendcsv():
     uf = io.open(fn, encoding='utf-8', mode='rt')
     actual = uf.read()
     eq_(expect, actual)
+
+
+def test_tocsv_none():
+
+    tbl = ((u'col1', u'colNone'),
+           (u'a', 1),
+           (u'b', None),
+           (u'c', None),
+           (u'd', 4))
+    fn = NamedTemporaryFile().name
+    tocsv(tbl, fn, encoding='utf-8', lineterminator='\n')
+
+    expect = (
+        u'col1,colNone\n'
+        u'a,1\n'
+        u'b,\n'
+        u'c,\n'
+        u'd,4\n'
+    )
+
+    uf = io.open(fn, encoding='utf-8', mode='rt', newline='')
+    actual = uf.read()
+    eq_(expect, actual)


### PR DESCRIPTION
Hi, 
i noticed that Petl tocsv() exports 'None' instead of no value if used with python 2.x. This produces wrong values if data is exported and re-loaded from csv.

Could we change that the unicode encoding is only applied for not-None values? 