### PR TITLE
Boolean interpretation of values in select() -> Fix #330

### DIFF
--- a/petl/test/transform/test_selects.py
+++ b/petl/test/transform/test_selects.py
@@ -113,6 +113,15 @@ def test_select_empty():
     ieq(expect, actual)
 
 
+def test_select_falsey():
+    table = (('foo',), 
+             ([],),
+             ('',))
+    expect = (('foo',),)
+    actual = select(table, '{foo}')
+    ieq(expect, actual)
+
+
 def test_selectgt():
 
     table = (('foo', 'bar', 'baz'),

--- a/petl/transform/selects.py
+++ b/petl/transform/selects.py
@@ -121,7 +121,7 @@ def iterfieldselect(source, field, where, complement, missing):
             v = getv(row)
         except IndexError:
             v = missing
-        if where(v) != complement:  # XOR
+        if bool(where(v)) != complement:  # XOR
             yield tuple(row)
 
 
@@ -132,7 +132,7 @@ def iterrowselect(source, where, missing, complement):
     yield tuple(hdr)
     it = (Record(row, flds, missing=missing) for row in it)
     for row in it:
-        if where(row) != complement:  # XOR
+        if bool(where(row)) != complement:  # XOR
             yield tuple(row)  # need to convert back to tuple?
 
 


### PR DESCRIPTION
akin to the stdlib `filter()`, `select()` should choose rows based on the truthiness of the test value rather than its equality to True or False.