### PR TITLE
add "strict" keyword doc for rename() function

### DIFF
--- a/petl/transform/headers.py
+++ b/petl/transform/headers.py
@@ -47,6 +47,9 @@ def rename(table, *args, **kwargs):
     The field to rename can be specified as an index (i.e., integer representing
     field position).
 
+    If any nonexistent fields are specified, the default behaviour is to raise
+    a `FieldSelectionError`. However, if `strict` keyword argument is `False`, any
+    nonexistent fields specified will be silently ignored.
     """
 
     return RenameView(table, *args, **kwargs)


### PR DESCRIPTION
I think this is a useful bit to add to rename()'s doc, especially as it represents a change in default behaviour from 0.x to 1.0.

Cheers,
psj
