### PR TITLE
Per email from Brad Maggard on 2015-09-16, addfieldusingcontext() doe…

### DIFF
--- a/petl/test/transform/test_basics.py
+++ b/petl/test/transform/test_basics.py
@@ -543,6 +543,39 @@ def test_addfieldusingcontext():
     ieq(expect, table3)
     ieq(expect, table3)
 
+def test_addfieldusingcontext_stateful():
+
+    table1 = (('foo', 'bar'),
+              ('A', 1),
+              ('B', 4),
+              ('C', 5),
+              ('D', 9))
+
+    expect = (('foo', 'bar', 'baz', 'quux'),
+              ('A', 1, 1, 5),
+              ('B', 4, 5, 10),
+              ('C', 5, 10, 19),
+              ('D', 9, 19, 19))
+
+    def upstream(prv, cur, nxt):
+        if prv is None:
+            return cur.bar
+        else:
+            return cur.bar + prv.baz
+
+    def downstream(prv, cur, nxt):
+        if nxt is None:
+            return prv.quux
+        elif prv is None:
+            return nxt.bar + cur.bar
+        else:
+            return nxt.bar + prv.quux
+
+    table2 = addfieldusingcontext(table1, 'baz', upstream)
+    table3 = addfieldusingcontext(table2, 'quux', downstream)
+    ieq(expect, table3)
+    ieq(expect, table3)
+
 
 def test_movefield():
 

--- a/petl/transform/basics.py
+++ b/petl/transform/basics.py
@@ -999,13 +999,14 @@ def iteraddfieldusingcontext(table, field, query):
     hdr = tuple(next(it))
     flds = list(map(text_type, hdr))
     yield hdr + (field,)
+    flds.append(field)
     it = (Record(row, flds) for row in it)
     prv = None
     cur = next(it)
     for nxt in it:
         v = query(prv, cur, nxt)
         yield tuple(cur) + (v,)
-        prv = cur
+        prv = Record(tuple(cur) + (v,), flds)
         cur = nxt
     # handle last row
     v = query(prv, cur, None)


### PR DESCRIPTION
Per email from Brad Maggard on 2015-09-16, addfieldusingcontext() doesn't have access to the new field, making calculations like running sum more complicated.

The generator yields the tuple from the original table.  It now creates a new Record() object with the additional field and the previous row's value, providing access to the prior row's new field.

I profiled both time and memory usage - the extra step of creating the Record() instance is minimal.

On a random table of 1MM rows, it added 100KB of memory at runtime and changed execution time from 63 seconds to 65 seconds on my test.