### PR TITLE
Utilize zip_longest to mirror behavior in fromdicts()

### DIFF
--- a/petl/io/base.py
+++ b/petl/io/base.py
@@ -4,7 +4,7 @@ from __future__ import division, print_function, absolute_import
 
 import locale
 import codecs
-
+from petl.compat import izip_longest
 
 from petl.util.base import Table
 
@@ -56,5 +56,5 @@ def itercolumns(cols, header):
     if header is None:
         header = ['f%s' % i for i in range(len(cols))]
     yield tuple(header)
-    for row in zip(*cols):
+    for row in izip_longest(*cols):
         yield row


### PR DESCRIPTION
`fromdicts()` creates a table with `None` fill if row lengths differ

    import petl
    dicts = [{"foo": "a", "bar": 1},
            {"foo": "b", "bar": 2},
            {"bar": 2}]
    tbl = petl.fromdicts(dicts)
    print(petl.lookall(tbl))

Proposed use of izip_longest (from petl.compat for 2.x/3.x compatibility) yields similar behavior:

    import petl
    
    cols = [[0, 1, 2, 3], ['a', 'b', 'c']]
    tbl = petl.fromcolumns(cols)
    print(petl.lookall(tbl))
