### PR TITLE
make XLSXView close the workbook after iterating

### DIFF
--- a/.travis.yml~
+++ b/.travis.yml~
@@ -1,9 +1,0 @@
-language: python
-python:
-#  - "3.3"
-  - "2.7"
-  - "2.6"
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: pip install nose
-# command to run tests, e.g. python setup.py test
-script:  nosetests

--- a/petl/io/xlsx.py
+++ b/petl/io/xlsx.py
@@ -60,6 +60,11 @@ class XLSXView(Table):
                                 row_offset=self.row_offset,
                                 column_offset=self.column_offset):
             yield tuple(cell.value for cell in row)
+        try:
+            wb._archive.close()
+        except AttributeError as e:
+            # just here in case openpyxl stops exposing an _archive property.
+            pass
 
 
 def toxlsx(tbl, filename, sheet=None, encoding=None):


### PR DESCRIPTION
openpyxl doesn't explicitly close the workbook after you are done iterating it.
This means that if you use petl and then try to rename or move the workbook you get a PermissionError
There's an issue to expose a workbook.close property directly but this will work until then.
https://bitbucket.org/openpyxl/openpyxl/issues/673/close-file-when-done