### PR TITLE
Added support for headerless csv files

### DIFF
--- a/petl/io/csv.py
+++ b/petl/io/csv.py
@@ -17,7 +17,8 @@ else:
         teecsv_impl
 
 
-def fromcsv(source=None, encoding=None, errors='strict', **csvargs):
+def fromcsv(source=None, encoding=None, errors='strict', header=None, 
+            **csvargs):
     """
     Extract a table from a delimited file. E.g.::
 
@@ -57,11 +58,12 @@ def fromcsv(source=None, encoding=None, errors='strict', **csvargs):
 
     source = read_source_from_arg(source)
     csvargs.setdefault('dialect', 'excel')
-    return fromcsv_impl(source=source, encoding=encoding, errors=errors,
-                        **csvargs)
+    return fromcsv_impl(source=source, encoding=encoding, errors=errors, 
+                        header=header, **csvargs)
 
 
-def fromtsv(source=None, encoding=None, errors='strict', **csvargs):
+def fromtsv(source=None, encoding=None, errors='strict', header=None, 
+            **csvargs):
     """
     Convenience function, as :func:`petl.io.csv.fromcsv` but with different
     default dialect (tab delimited).

--- a/petl/io/csv_py2.py
+++ b/petl/io/csv_py2.py
@@ -18,7 +18,7 @@ def fromcsv_impl(source, **kwargs):
 
 class CSVView(Table):
 
-    def __init__(self, source=None, encoding=None, errors='strict', header=None **csvargs):
+    def __init__(self, source=None, encoding=None, errors='strict', header=None, **csvargs):
             self.source = source
             self.encoding = encoding
             self.errors = errors

--- a/petl/io/csv_py2.py
+++ b/petl/io/csv_py2.py
@@ -18,13 +18,16 @@ def fromcsv_impl(source, **kwargs):
 
 class CSVView(Table):
 
-    def __init__(self, source=None, encoding=None, errors='strict', **csvargs):
+    def __init__(self, source=None, encoding=None, errors='strict', header=None **csvargs):
             self.source = source
             self.encoding = encoding
             self.errors = errors
             self.csvargs = csvargs
+            self.header = header
 
     def __iter__(self):
+        if self.header is not None:
+          yield tuple(self.header)
 
         # determine encoding
         codec = getcodec(self.encoding)

--- a/petl/io/csv_py3.py
+++ b/petl/io/csv_py3.py
@@ -19,13 +19,16 @@ def fromcsv_impl(source, **kwargs):
 
 class CSVView(Table):
 
-    def __init__(self, source, encoding, errors, **csvargs):
+    def __init__(self, source, encoding, errors, header, **csvargs):
             self.source = source
             self.encoding = encoding
             self.errors = errors
             self.csvargs = csvargs
+            self.header = header
 
     def __iter__(self):
+        if self.header is not None:
+          yield tuple(self.header)
         with self.source.open('rb') as buf:
             csvfile = io.TextIOWrapper(buf, encoding=self.encoding,
                                        errors=self.errors, newline='')

--- a/petl/test/io/test_csv.py
+++ b/petl/test/io/test_csv.py
@@ -290,3 +290,22 @@ def test_tocsv_appendcsv_gz():
         eq_(expect, actual)
     finally:
         o.close()
+        
+def test_fromcsv_header():
+
+    header = ['foo', 'bar']
+    data = [b'a,1',
+            b'b,2',
+            b'c,2']
+    f = NamedTemporaryFile(mode='wb', delete=False)
+    f.write(b'\n'.join(data))
+    f.close()
+
+    expect = (('foo', 'bar'),
+              ('a', '1'),
+              ('b', '2'),
+              ('c', '2'))
+    actual = fromcsv(f.name, encoding='ascii', header=header)
+    debug(actual)
+    ieq(expect, actual)
+    ieq(expect, actual)  # verify can iterate twice


### PR DESCRIPTION
Added an optional header argument to fromcsv/fromtsv to allow
specificying headers for the file instead of taking the first row